### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ or [Building Lemon OS](https://github.com/fido2020/Lemon-OS/wiki/Building-Lemon-
 - XHCI Driver
 
 ### System requirements
-- 256 MB RAM (512 is more optimal)
+- 256 MB RAM (512 is closer to the optimal amount)
 - x86_64 Processor
 - 2 cores/CPUs recommended
 - I/O APIC


### PR DESCRIPTION
"More optimal" is grammatically correct but logically meaningless. In other words, there's no grammatical problem with the phrase, but the meaning of "optimal" is logically incompatible with the meaning of "more."