### PR TITLE
Add bash shebang to toolchain build script

### DIFF
--- a/Toolchain/buildtoolchain.sh
+++ b/Toolchain/buildtoolchain.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 SPATH=$(dirname $(readlink -f "$0"))
 
 cd $SPATH/..


### PR DESCRIPTION
`pushd` and `popd` are bash-specific extensions, so the script does not properly work when run under (for example) zsh. This specifies that bash should be used.